### PR TITLE
debug alternate skybound g2 programmer firmware

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,11 @@
+
+# https://github.com/jdx/mise
+[tools]
+yq = 'latest'
+python = "3.12.3"
+
+[env]
+_.python.venv = { path = "{{config_root}}/venv", create = false }
+
+PYTHONPATH="{{config_root}}/src"
+

--- a/src/jdmtool/main.py
+++ b/src/jdmtool/main.py
@@ -10,6 +10,7 @@ except ImportError:
     import importlib_metadata
 from io import TextIOWrapper
 import json
+import logging
 import os
 import pathlib
 import shutil
@@ -56,6 +57,8 @@ DETAILED_INFO_MAP = [
     ("Next Version Available Date", "next_version_avail_date"),
     ("Next Version Start Date", "next_version_start_date"),
 ]
+
+log = logging.getLogger("main")
 
 
 class IdPreset(Enum):
@@ -980,6 +983,7 @@ def main():
     parser = argparse.ArgumentParser(description="Download and transfer Jeppesen databases")
 
     parser.add_argument('--version', action='version', version=importlib_metadata.version('jdmtool'))
+    parser.add_argument('-v', "--verbose", action='store_true', help="set verbose logging")
 
     subparsers = parser.add_subparsers(metavar="<command>")
     subparsers.required = True
@@ -1102,6 +1106,14 @@ def main():
     args = parser.parse_args()
 
     kwargs = vars(args)
+
+    verbose = kwargs.pop('verbose')
+    if verbose: 
+        logging.basicConfig(level=logging.DEBUG)
+        log.info("Log level set to DEBUG")
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
     func = kwargs.pop('func')
 
     try:

--- a/src/jdmtool/skybound.py
+++ b/src/jdmtool/skybound.py
@@ -64,8 +64,8 @@ class SkyboundDevice():
 
     def init(self) -> None:
         buf = self.control_read(0x80, 0x06, 0x0100, 0x0000, 18)
-        log.info(f"Response 0: {buf.hex(' ')}")
-        log.info(f"          : {KNOWN_FIRMWARE_RESPONSES['20071203']['responses'][0].hex(' ')}")
+        log.info(f"Response 0: {buf.hex('\x')}")
+        log.info(f"          : {KNOWN_FIRMWARE_RESPONSES['20071203']['responses'][0].hex('\x')}")
 
         if buf != b"\x12\x01\x10\x01\xFF\x83\xFF\x40\x39\x0E\x50\x12\x00\x00\x00\x00\x00\x01":
             log.warning(f"Unexpected response 0 {buf}")

--- a/src/jdmtool/skybound.py
+++ b/src/jdmtool/skybound.py
@@ -1,7 +1,19 @@
 from typing import Iterable
 
+import logging
 import usb1
 
+
+log = logging.getLogger(__name__)
+
+KNOWN_FIRMWARE_RESPONSES={
+    "20071203": {
+
+    },
+    "": {
+        
+    }
+}
 
 class SkyboundException(Exception):
     pass

--- a/src/jdmtool/skybound.py
+++ b/src/jdmtool/skybound.py
@@ -8,10 +8,17 @@ log = logging.getLogger(__name__)
 
 KNOWN_FIRMWARE_RESPONSES={
     "20071203": {
-
+        "responses": [
+            b"\x12\x01\x10\x01\xFF\x83\xFF\x40\x39\x0E\x50\x12\x00\x00\x00\x00\x00\x01",
+            b"\x09\x02\x20\x00\x01\x01\x00\x80\x0F",
+            b"\x09\x02\x20\x00\x01\x01\x00\x80\x0F\x09\x04\x00\x00\x02\x00\x00"
+            b"\x00\x00\x07\x05\x81\x02\x40\x00\x05\x07\x05\x02\x02\x40\x00\x05"
+        ]
     },
-    "": {
-        
+    "20140530": {
+        "responses": [
+
+        ]
     }
 }
 
@@ -57,17 +64,32 @@ class SkyboundDevice():
 
     def init(self) -> None:
         buf = self.control_read(0x80, 0x06, 0x0100, 0x0000, 18)
+        log.info(f"Response 0: {buf.hex(' ')}")
+        log.info(f"          : {KNOWN_FIRMWARE_RESPONSES['20071203']['responses'][0].hex(' ')}")
+
         if buf != b"\x12\x01\x10\x01\xFF\x83\xFF\x40\x39\x0E\x50\x12\x00\x00\x00\x00\x00\x01":
-            raise SkyboundException("Unexpected response")
+            log.warning(f"Unexpected response 0 {buf}")
+            #raise SkyboundException("Unexpected response")
+        
+        
         buf = self.control_read(0x80, 0x06, 0x0200, 0x0000, 9)
+        log.info(f"Response 1: {buf.hex(' ')}")
+        log.info(f"          : {KNOWN_FIRMWARE_RESPONSES['20071203']['responses'][1].hex(' ')}")
+
         if buf != b"\x09\x02\x20\x00\x01\x01\x00\x80\x0F":
-            raise SkyboundException("Unexpected response")
+            log.warning(f"Unexpected response 1 {buf}")
+            #raise SkyboundException("Unexpected response")
+
+
         buf = self.control_read(0x80, 0x06, 0x0200, 0x0000, 32)
+        log.info(f"Response 2: {buf.hex(' ')}")
+        log.info(f"          : {KNOWN_FIRMWARE_RESPONSES['20071203']['responses'][2].hex(' ')}")
         if buf != (
             b"\x09\x02\x20\x00\x01\x01\x00\x80\x0F\x09\x04\x00\x00\x02\x00\x00"
             b"\x00\x00\x07\x05\x81\x02\x40\x00\x05\x07\x05\x02\x02\x40\x00\x05"
         ):
-            raise SkyboundException("Unexpected response")
+            log.warning(f"Unexpected response 2 {buf}")
+            #raise SkyboundException("Unexpected response")
 
     def set_led(self, on: bool) -> None:
         if on:

--- a/udev/readme.md
+++ b/udev/readme.md
@@ -1,0 +1,10 @@
+
+# Installing udev
+
+## Ubuntu 22.04 (likely other debian variants)
+
+To install and reload udev rules on ubuntu:
+
+    sudo cp 50-skybound.rules /etc/udev/rules.d/
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger


### PR DESCRIPTION
I think this idea is amazing, and would really love to contribute.

I found that I have a different firmware version on my Skybound G2, it is returning different byte array responses from the `init()` method reads.  After init, things seem to be fine.  I tried to make `skybound.py` support other firmware versions - as well as leave it open to other potential firmwares by adding to `KNOWN_FIRMWARE_RESPONSES`.  

I also wanted to introduce non-intrusive debug logging.  I added a `-v` (verbose) flag - and use that to initialize python logging.  This allows for some verbose debugging without affecting clean the output of the tool if we don't enable debugging.

After this - I got to a different defect, I'm going to log an issue for that. 

Without verbose flag:
```
jdmtool detect
Found device: Bus 001 Device 007: ID 0e39:1250
Firmware version: 20140530
Card inserted:
  IID: 0x89007e00
  Unknown identifier: 0x3c009000

```

With verbose flag:
```
jdmtool -v detect
INFO:main:Log level set to DEBUG
Found device: Bus 001 Device 007: ID 0e39:1250
DEBUG:jdmtool.skybound:Checking known responses from 20071203
DEBUG:jdmtool.skybound:  Response[0]: 12 01 10 01 ff 83 ff 40 39 0e 50 12 00 00 00 00 00 01
DEBUG:jdmtool.skybound:  Expected[0]: 12 01 10 01 ff 83 ff 40 39 0e 50 12 00 00 00 00 00 01
DEBUG:jdmtool.skybound:  Response[1]: 09 02 20 00 01 01 00 80 32
DEBUG:jdmtool.skybound:  Expected[1]: 09 02 20 00 01 01 00 80 0f
DEBUG:jdmtool.skybound:  Response[2]: 09 02 20 00 01 01 00 80 32 09 04 00 00 02 00 00 00 00 07 05 81 02 40 00 05 07 05 02 02 40 00 05
DEBUG:jdmtool.skybound:  Expected[2]: 09 02 20 00 01 01 00 80 0f 09 04 00 00 02 00 00 00 00 07 05 81 02 40 00 05 07 05 02 02 40 00 05
DEBUG:jdmtool.skybound:----------
DEBUG:jdmtool.skybound:Checking known responses from 20140530
DEBUG:jdmtool.skybound:  Response[0]: 12 01 10 01 ff 83 ff 40 39 0e 50 12 00 00 00 00 00 01
DEBUG:jdmtool.skybound:  Expected[0]: 12 01 10 01 ff 83 ff 40 39 0e 50 12 00 00 00 00 00 01
DEBUG:jdmtool.skybound:  Response[1]: 09 02 20 00 01 01 00 80 32
DEBUG:jdmtool.skybound:  Expected[1]: 09 02 20 00 01 01 00 80 32
DEBUG:jdmtool.skybound:  Response[2]: 09 02 20 00 01 01 00 80 32 09 04 00 00 02 00 00 00 00 07 05 81 02 40 00 05 07 05 02 02 40 00 05
DEBUG:jdmtool.skybound:  Expected[2]: 09 02 20 00 01 01 00 80 32 09 04 00 00 02 00 00 00 00 07 05 81 02 40 00 05 07 05 02 02 40 00 05
DEBUG:jdmtool.skybound:----------
INFO:jdmtool.skybound:Response array matches 20140530, responses are valid
Firmware version: 20140530
Card inserted:
  IID: 0x89007e00
  Unknown identifier: 0x3c009000

```