### PR TITLE
Support orange data card

### DIFF
--- a/src/jdmtool/main.py
+++ b/src/jdmtool/main.py
@@ -20,7 +20,7 @@ import zipfile
 import psutil
 import tqdm
 
-from .skybound import SkyboundDevice, SkyboundException, CARDS
+from .skybound import SkyboundDevice, SkyboundException
 from .downloader import Downloader, DownloaderException, GRM_FEAT_KEY
 from .service import Service, ServiceException, SimpleService, get_data_dir, get_downloads_dir, load_services
 
@@ -107,9 +107,7 @@ def with_data_card(f: Callable):
         dev.before_read()
 
         # TODO: Figure out the actual meaning of the iid and the "unknown" value.
-        iid = dev.get_iid()
-
-        card = CARDS.get(iid)
+        card = dev.get_card()
 
         log.debug(f"Detected card: {card}")
 
@@ -118,7 +116,7 @@ def with_data_card(f: Callable):
             dev.set_memory_layout(card.memory_layout)
         else:
             raise SkyboundException(
-                f"Unknown data card IID: 0x{iid:08x} (possibly 8MB non-WAAS?). Please file a bug!"
+                f"Unknown data card IID: 0x{dev.get_iid():08x} (possibly 8MB non-WAAS?). Please file a bug!"
             )
 
         f(dev, *args, **kwargs)
@@ -826,7 +824,7 @@ def cmd_detect(dev: SkyboundDevice) -> None:
         dev.before_read()
         iid = dev.get_iid()
         print(f"  IID: 0x{iid:08x}")
-        card = CARDS.get(iid)
+        card = SkyboundDevice.CARDS.get(iid)
         print(f"  Type: {card.type if card else 'non-recognized'}")
 
         unknown = dev.get_unknown()

--- a/src/jdmtool/main.py
+++ b/src/jdmtool/main.py
@@ -93,6 +93,9 @@ def with_usb(f: Callable):
     return wrapper
 
 
+
+
+
 def with_data_card(f: Callable):
     @wraps(f)
     @with_usb

--- a/src/jdmtool/skybound.py
+++ b/src/jdmtool/skybound.py
@@ -15,7 +15,7 @@ class MemoryCard:
     memory_layout: list[int]
 
     def __repr__(self) -> str:
-        return f"iid: {self.iid}, type: {self.type}"
+        return f"iid: 0x{self.iid:08x}, type: {self.type}"
 
 
 class SkyboundDevice():

--- a/src/jdmtool/skybound.py
+++ b/src/jdmtool/skybound.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
 from dataclasses import dataclass
 
 if TYPE_CHECKING:
@@ -10,26 +10,29 @@ class SkyboundException(Exception):
 
 @dataclass
 class MemoryCard:
-    name: str
+    type: str
     iid: int
     memory_layout: list[int]
 
+    def __repr__(self) -> str:
+        return f"iid: {self.iid}, type: {self.type}"
+
 CARDS = {
-    card.iid: card for cards in [
+    card.iid: card for card in [
         MemoryCard(
-            name="16mb IFRW (WAAS) Orange", 
+            type="16mb IFRW (WAAS) Orange", 
             iid=0x89007e00,
             memory_layout=[0, 1, 2, 3, 4, 5, 6, 7],
         ),
         MemoryCard(
-            name="16Mb IFRW (WAAS) Silver",
+            type="16Mb IFRW (WAAS) Silver",
             iid=0x01004100,
             memory_layout=[0, 1, 2, 3, 4, 5, 6, 7],
         ),
         MemoryCard(
-            name="4Mb IFR (non-WAAS)",
+            type="4Mb IFR (non-WAAS)",
             iid= 0x0100ad00,
-            memory_layout=[0, 1, 2, 3, 4, 5, 6, 7],
+            memory_layout=[0, 2],
         ),
     ]
 }
@@ -96,6 +99,9 @@ class SkyboundDevice():
         self.write(b"\x50\x04")
         buf = self.read(0x0040)
         return int.from_bytes(buf, 'little')
+    
+    def get_card(self) -> MemoryCard | None:
+        return CARDS.get(self.get_iid())
 
     def read_block(self) -> bytes:
         self.write(b"\x28")

--- a/src/jdmtool/skybound.py
+++ b/src/jdmtool/skybound.py
@@ -17,25 +17,6 @@ class MemoryCard:
     def __repr__(self) -> str:
         return f"iid: {self.iid}, type: {self.type}"
 
-CARDS = {
-    card.iid: card for card in [
-        MemoryCard(
-            type="16mb IFRW (WAAS) Orange", 
-            iid=0x89007e00,
-            memory_layout=[0, 1, 2, 3, 4, 5, 6, 7],
-        ),
-        MemoryCard(
-            type="16Mb IFRW (WAAS) Silver",
-            iid=0x01004100,
-            memory_layout=[0, 1, 2, 3, 4, 5, 6, 7],
-        ),
-        MemoryCard(
-            type="4Mb IFR (non-WAAS)",
-            iid= 0x0100ad00,
-            memory_layout=[0, 2],
-        ),
-    ]
-}
 
 class SkyboundDevice():
     VID = 0x0E39
@@ -56,6 +37,27 @@ class SkyboundDevice():
     MEMORY_LAYOUT_UNKNOWN = [0]
     MEMORY_LAYOUT_4MB = [0, 2]
     MEMORY_LAYOUT_16MB = [0, 1, 2, 3, 4, 5, 6, 7]
+
+    CARDS = {
+        card.iid: card for card in [
+            MemoryCard(
+                type="16mb IFRW (WAAS) Orange", 
+                iid=0x89007e00,
+                memory_layout=[0, 1, 2, 3, 4, 5, 6, 7],
+            ),
+            MemoryCard(
+                type="16Mb IFRW (WAAS) Silver",
+                iid=0x01004100,
+                memory_layout=[0, 1, 2, 3, 4, 5, 6, 7],
+            ),
+            MemoryCard(
+                type="4Mb IFR (non-WAAS)",
+                iid= 0x0100ad00,
+                memory_layout=[0, 2],
+            ),
+        ]
+    }
+
 
     def __init__(self, handle: 'USBDeviceHandle') -> None:
         self.handle = handle
@@ -101,7 +103,7 @@ class SkyboundDevice():
         return int.from_bytes(buf, 'little')
     
     def get_card(self) -> MemoryCard | None:
-        return CARDS.get(self.get_iid())
+        return self.CARDS.get(self.get_iid())
 
     def read_block(self) -> bytes:
         self.write(b"\x28")

--- a/src/jdmtool/skybound.py
+++ b/src/jdmtool/skybound.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING, Iterable
+from dataclasses import dataclass
 
 if TYPE_CHECKING:
     from usb1 import USBDeviceHandle
@@ -7,6 +8,31 @@ if TYPE_CHECKING:
 class SkyboundException(Exception):
     pass
 
+@dataclass
+class MemoryCard:
+    name: str
+    iid: int
+    memory_layout: list[int]
+
+CARDS = {
+    card.iid: card for cards in [
+        MemoryCard(
+            name="16mb IFRW (WAAS) Orange", 
+            iid=0x89007e00,
+            memory_layout=[0, 1, 2, 3, 4, 5, 6, 7],
+        ),
+        MemoryCard(
+            name="16Mb IFRW (WAAS) Silver",
+            iid=0x01004100,
+            memory_layout=[0, 1, 2, 3, 4, 5, 6, 7],
+        ),
+        MemoryCard(
+            name="4Mb IFR (non-WAAS)",
+            iid= 0x0100ad00,
+            memory_layout=[0, 1, 2, 3, 4, 5, 6, 7],
+        ),
+    ]
+}
 
 class SkyboundDevice():
     VID = 0x0E39


### PR DESCRIPTION
Closes: https://github.com/dimaryaz/jdmtool/issues/11

Tried to create a dataclass to encapsulate attributes of various memory cards.

Detect works:
```
jdmtool detect
Found device: Bus 001 Device 008: ID 0e39:1250
Firmware version: 20140530
Card inserted:
  IID: 0x89007e00
  Type: 16mb IFRW (WAAS) Orange
  Unknown identifier: 0x3c009000=
```

I was also able to download and verify:
```
jdmtool -v read-database db.bin
INFO:main:Log level set to DEBUG
Found device: Bus 001 Device 008: ID 0e39:1250
DEBUG:main:Detected card: MemoryCard(name='16mb IFRW (WAAS) Orange', iid=2298510848, memory_layout=[0, 1, 2, 3, 4, 5, 6, 7])
Detected data card: MemoryCard(name='16mb IFRW (WAAS) Orange', iid=2298510848, memory_layout=[0, 1, 2, 3, 4, 5, 6, 7])
Reading the database:  51%|████████████████████████████████████████████████████▎                                                 | 8.60M/16.8M [01:34<01:29, 91.4kB/s]
Truncating the file...
Done

file db.bin 
db.bin: DOS/MBR boot sector, code offset 0x3c+2, OEM-ID "GARMIN10", sectors/cluster 8, FAT  1, root entries 512, sectors 32768 (volumes <=32 MB), sectors/FAT 16, sectors/track 63, heads 255, hidden sectors 63, serial number 0x1102, label: "GARMIN AT  ", FAT (16 bit)
```

And write: 
```
jdmtool transfer 0
Found device: Bus 001 Device 008: ID 0e39:1250
Detected data card: iid: 0x89007e00, type: 16mb IFRW (WAAS) Orange

Selected service:
  Garmin GNS 400/500 Series WAAS - NavData                              2408    2024-08-08 - 2024-09-05

Transfer to the data card? (y/n) y
Erasing the database: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 8.72M/8.72M [02:26<00:00, 59.4kB/s]
Writing the database: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████| 8.65M/8.65M [05:09<00:00, 27.9kB/s]
Verifying the database: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████| 8.65M/8.65M [01:34<00:00, 91.5kB/s]
Writing new metadata: {2408~42323550}
Done

```