### PR TITLE
fix crash if chartview.hif does not exists

### DIFF
--- a/src/jdmtool/featunlk.py
+++ b/src/jdmtool/featunlk.py
@@ -479,15 +479,17 @@ def display_content_of_dat_file(feature: Feature, dat_file: pathlib.Path):
         cus_date2 = datetime.date(t_year, t_month, t_day).strftime(format_date).upper()
         print(f'** Effective {cus_date1} to {cus_date2}')    
     elif feature in (Feature.CHARTVIEW, ):
-        with open(dat_file.parent / 'chartview.hif', 'rb') as fd:
-            header_bytes = fd.read(0x200)
-        print('** ' + header_bytes[0x0A:0x0A+9].decode('ascii'))
-        print('** Cycle: ' + header_bytes[0x23:0x23+7].decode('ascii'))
-        with open(dat_file.parent / 'charts.ini', 'rb') as fd:
-            header_bytes = fd.read(0x200)
-        cus_date1 = datetime.date.fromordinal(int(header_bytes[30:30+7].decode('ascii'))- 1721424).strftime(format_date).upper()
-        cus_date2 = datetime.date.fromordinal(int(header_bytes[59:59+7].decode('ascii'))- 1721424).strftime(format_date).upper()
-        print(f'** Effective {cus_date1} to {cus_date2}') 
+        if (dat_file.parent / 'chartview.hif').is_file():
+            with open(dat_file.parent / 'chartview.hif', 'rb') as fd:
+                header_bytes = fd.read(0x200)
+            print('** ' + header_bytes[0x0A:0x0A+9].decode('ascii'))
+            print('** Cycle: ' + header_bytes[0x23:0x23+7].decode('ascii'))
+        if (dat_file.parent / 'charts.ini').is_file():
+            with open(dat_file.parent / 'charts.ini', 'rb') as fd:
+                header_bytes = fd.read(0x200)
+            cus_date1 = datetime.date.fromordinal(int(header_bytes[30:30+7].decode('ascii'))- 1721424).strftime(format_date).upper()
+            cus_date2 = datetime.date.fromordinal(int(header_bytes[59:59+7].decode('ascii'))- 1721424).strftime(format_date).upper()
+            print(f'** Effective {cus_date1} to {cus_date2}')
     elif feature in (Feature.SAFETAXI, Feature.BASEMAP, Feature.BASEMAP2):
         xor_byte = header_bytes[0x00]
         if xor_byte:


### PR DESCRIPTION
chartview.hif is not part of the chartview zip, so it is likely this file does not exist. Check before accessing.